### PR TITLE
#4-API 사용자 처리

### DIFF
--- a/src/main/java/com/jwt/test/api01/controller/SampleController.java
+++ b/src/main/java/com/jwt/test/api01/controller/SampleController.java
@@ -1,2 +1,20 @@
-package com.jwt.test.api01.controller;public class SampleController {
+package com.jwt.test.api01.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/sample")
+public class SampleController {
+
+    @Operation
+    @RequestMapping("/doA")
+    public List<String> doA(){
+        return Arrays.asList("AAA","BBB","ccc");
+    }
+
 }

--- a/src/main/java/com/jwt/test/api01/domain/APIUser.java
+++ b/src/main/java/com/jwt/test/api01/domain/APIUser.java
@@ -1,2 +1,21 @@
-package com.jwt.test.api01.domain;public class APIUser {
+package com.jwt.test.api01.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class APIUser {
+    @Id
+    private String mid;
+    private String mpw;
+
+    public void changePw(String mpw){
+        this.mpw = mpw;
+    }
 }

--- a/src/main/java/com/jwt/test/api01/dto/APIUserDTO.java
+++ b/src/main/java/com/jwt/test/api01/dto/APIUserDTO.java
@@ -1,2 +1,24 @@
-package com.jwt.test.api01.dto;public class APIUserDTO {
+package com.jwt.test.api01.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+
+@Getter
+@Setter
+@ToString
+public class APIUserDTO extends User {
+    private String mid;
+    private String mpw;
+
+    public APIUserDTO(String username, String password, Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+        this.mid = username;
+        this.mpw = password;
+    }
+
 }

--- a/src/main/java/com/jwt/test/api01/repository/APIUserRepository.java
+++ b/src/main/java/com/jwt/test/api01/repository/APIUserRepository.java
@@ -1,2 +1,7 @@
-package com.jwt.test.api01.repository;public interface APIUserRepository {
+package com.jwt.test.api01.repository;
+
+import com.jwt.test.api01.domain.APIUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface APIUserRepository extends JpaRepository<APIUser,String> {
 }

--- a/src/main/java/com/jwt/test/api01/security/APIUserDetailService.java
+++ b/src/main/java/com/jwt/test/api01/security/APIUserDetailService.java
@@ -1,2 +1,39 @@
-package com.jwt.test.api01.security;public class APIUserDetailService {
+package com.jwt.test.api01.security;
+
+import com.jwt.test.api01.domain.APIUser;
+import com.jwt.test.api01.dto.APIUserDTO;
+import com.jwt.test.api01.repository.APIUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Log4j2
+@RequiredArgsConstructor
+
+@Service
+public class APIUserDetailService implements UserDetailsService {
+
+    private final APIUserRepository apiUserRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<APIUser> result = apiUserRepository.findById(username);
+        APIUser apiUser = result.orElseThrow(()-> new UsernameNotFoundException("cannot find mid"));
+
+        log.info("APIUserDetailsService apiUser----------------------------------");
+
+        APIUserDTO dto = new APIUserDTO(
+                apiUser.getMid(),
+                apiUser.getMpw(),
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        log.info(dto);
+        return dto;
+    }
 }


### PR DESCRIPTION
- APIUser : 엔티티
- APIUserRepository(<- JpaRepository<APIUser,String> : respository
- APIUserRepositoryTests: 다수의 임의 유저 생성을 위한 insert 코드
- APIUserDetailsService(<-UserDetailsService)
> @RequiredArgsConstructor: 생성자를 자동으로 생성해줌. 
> loadUserByUsername: 내부에 해당 사용자가 존재할 때 dto 반환하도록 구현. 모든 사용자는 ROLE_USER 권한 가짐.
-APIUserDto(<- User) : dto